### PR TITLE
Fix zip header name with wrong sep

### DIFF
--- a/zip.go
+++ b/zip.go
@@ -93,10 +93,11 @@ func zipFile(w *zip.Writer, source string) error {
 
 		if baseDir != "" {
 			name, err := filepath.Rel(source, fpath)
+			name = strings.Replace(name, string(os.PathSeparator), "/", -1)
 			if err != nil {
 				return err
 			}
-			header.Name = path.Join(baseDir, name)
+			header.Name = strings.Join([]string{baseDir, name}, "/")
 		}
 
 		if info.IsDir() {


### PR DESCRIPTION
When compress a folder contains subdirectory to zip on windows and then uncompress on *nix, the files in subdirectory will in a flatten level. Its' unexpected.